### PR TITLE
small improvements for CRAN checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggparty
 Title: 'ggplot' Visualizations for the 'partykit' Package
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
   person("Martin", "Borkovec", role = c("aut", "cre"), email = "martin.borkovec@skyforge.at"), 
   person("Niyaz", "Madin", role = c("aut"), email = "niyaz.madin@gmail.com"),
@@ -26,13 +26,13 @@ Imports:
   utils,
   checkmate,
   methods,
-  survival,
   rlang
 Suggests:
     testthat,
     mlbench,
     AER,
     coin,
+    survival,
     vdiffr,
     knitr,
     rmarkdown,
@@ -43,7 +43,6 @@ License: GPL-2 | GPL-3
 URL: https://github.com/martin-borkovec/ggparty
 BugReports: https://github.com/martin-borkovec/ggparty/issues
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr

--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -2,6 +2,10 @@
 title: "Changes"
 output: rmarkdown::github_document
 ---
+### version 1.0.1.
+
+* small improvements in the DESCRIPTION etc. for CRAN checks.
+
 ### version 1.0.0.
 
 * finalized DESCRIPTION etc. for CRAN submission

--- a/vignettes/ggparty-graphic-partying.Rmd
+++ b/vignettes/ggparty-graphic-partying.Rmd
@@ -4,8 +4,9 @@ author: "Martin Borkovec"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{ggparty}
+  %\VignetteIndexEntry{ggparty: Graphic Partying}
   %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteDepends{ggparty,survival,pander}
   %\VignetteEncoding{UTF-8}   
 ---
 <style>
@@ -29,7 +30,7 @@ to create clearly structured and highly customizable visualizations for tree-obj
 Loading the **ggparty** package will also load **partykit** and **ggplot2** and thereby provide all necessary functions.  
 
 ```{r}
-library(ggparty)
+library("ggparty")
 ```
 
 ## Motivating Example

--- a/vignettes/on-the-edge.Rmd
+++ b/vignettes/on-the-edge.Rmd
@@ -1,11 +1,12 @@
 ---
-title: "On The Edge"
+title: "On the Edge"
 author: "Martin Borkovec"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{edges}
+  %\VignetteIndexEntry{On the Edge}
   %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteDepends{ggparty,MASS}
   %\VignetteEncoding{UTF-8}   
 ---
 <style>
@@ -30,7 +31,7 @@ First let's once more recreate the **WeatherPlay** tree. But this time we are go
 level of **outlook** to "beta"
 
 ```{r, echo = T, message= FALSE}
-library(ggparty) 
+library("ggparty") 
 data("WeatherPlay", package = "partykit")
 levels(WeatherPlay$outlook)[1] <- c("beta")
 sp_o <- partysplit(1L, index = 1:3)
@@ -137,7 +138,7 @@ In the presence of several levels for some splits we can use the argument `split
 
 
 ```{r}
-library(MASS)
+library("MASS")
 SexTest <- ctree(sex ~ ., data = Aids2)
 ggparty(SexTest) +
   geom_edge() + 
@@ -151,7 +152,7 @@ ggparty(SexTest) +
 
 Alternatively the argument `max_length`provides an option to easily truncate the names of the levels.
 ```{r}
-library(MASS)
+library("MASS")
 SexTest <- ctree(sex ~ ., data = Aids2)
 ggparty(SexTest) +
   geom_edge() + 


### PR DESCRIPTION
Martin,

I noticed that CRAN checks for `ggparty` are producing a couple of NOTEs which were easy to address: Omit `LazyData` in `DESCRIPTION` (because there is no data) and move `survival` from `Imports` to `Suggests` as it is only used in a vignette.

Looking at the vignettes I thought it would be good to add explicit `VignetteDepends` declarations and bring `VignetteIndexEntry` into sync with the actual document title.

Best wishes,
Achim