### PR TITLE
Option to round numbers in edge labels a continuous split

### DIFF
--- a/R/ggparty.R
+++ b/R/ggparty.R
@@ -364,7 +364,7 @@ parse_signs <- function(label, splitlevels = NULL, max_length = NULL, round_digi
       if(!is.null(round_digits))
         label[i] <- paste(first[i], unlist(lapply(round(as.numeric(last[i]), digits = round_digits), FUN = deparse)))
       else
-        label[i] <- paste0(first[i], unlist(lapply(last[i], FUN = deparse)))
+        label[i] <- paste(first[i], unlist(lapply(last[i], FUN = deparse)))
     else {
       if (!is.null(splitlevels)) {
         label[i] <- vapply(label[i], function(x) {

--- a/man/geom_edge_label.Rd
+++ b/man/geom_edge_label.Rd
@@ -4,10 +4,20 @@
 \alias{geom_edge_label}
 \title{Draw edge labels}
 \usage{
-geom_edge_label(mapping = NULL, nudge_x = 0, nudge_y = 0,
-  ids = NULL, shift = 0.5, label.size = 0,
-  splitlevels = seq_len(100), max_length = NULL, parse_all = FALSE,
-  parse = TRUE, ...)
+geom_edge_label(
+  mapping = NULL,
+  nudge_x = 0,
+  nudge_y = 0,
+  ids = NULL,
+  shift = 0.5,
+  label.size = 0,
+  splitlevels = seq_len(100),
+  max_length = NULL,
+  parse_all = FALSE,
+  parse = TRUE,
+  round_digits = NULL,
+  ...
+)
 }
 \arguments{
 \item{mapping}{Mapping of \code{label} label defaults to \strong{breaks_label}. Other
@@ -30,6 +40,8 @@ presence of many factor levels for one split break.}
 signs of \strong{breaks_label} are deparsed. If \code{TRUE} complete \strong{breaks_label} are parsed.}
 
 \item{parse}{Needs to be true in order to parse inequality signs of \strong{breaks_label}.}
+
+\item{round_digits}{if not null, rounds digits for continuous splits.}
 
 \item{...}{Additional arguments for \code{\link[=geom_label]{geom_label()}}.}
 }


### PR DESCRIPTION
Adding a `round_digits` option in `geom_edge_label(round_digits = 1)` (for example) to round labels

Before
<img width="384" alt="image" src="https://user-images.githubusercontent.com/33321678/161403005-78e7b33f-74d5-471f-a138-1efc2153fc79.png">


After
<img width="294" alt="image" src="https://user-images.githubusercontent.com/33321678/161402995-5f0c9358-f808-4fab-9816-8820609778dd.png">
 